### PR TITLE
Improve clarity of example comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ assert.deepEqual(findLastIndex(arr, isNumber), 3);
 ```js
 var findLastIndex = require('array.prototype.findlastindex');
 var assert = require('assert');
-/* when Array#findLastIndex is not present */
+/* when Array#findLastIndex is present */
 delete Array.prototype.findLastIndex;
 var shimmed = findLastIndex.shim();
 
@@ -47,7 +47,7 @@ assert.deepEqual(arr.findLastIndex(isNumber), findLastIndex(arr, isNumber));
 ```js
 var findLastIndex = require('array.prototype.findlastindex');
 var assert = require('assert');
-/* when Array#findLastIndex is present */
+/* when Array#findLastIndex is not present */
 var shimmed = findLastIndex.shim();
 
 assert.equal(shimmed, Array.prototype.findLastIndex);


### PR DESCRIPTION
Hi @ljharb, hope things are good with you!

Reading the comments in the readme examples left me a bit confused - if `Array.prototype.findLastIndex` is not present, then why would it need to be deleted? I swapped "not present" and "present" in the examples, in case my understanding is correct.

Alternatives considered: maybe I'm misunderstanding the comment and it is indeed correct as it is